### PR TITLE
Update from upstream

### DIFF
--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -29,6 +29,24 @@ jobs:
       - name: Build images
         run: poetry run build
 
+      - name: Install Trivy
+        run: |
+          sudo apt-get install wget apt-transport-https gnupg lsb-release
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+          echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install trivy
+
+          # Update the DB so we can skip it later
+          trivy image --download-db-only
+
+      - name: Trivy security scan
+        run: |
+          IMAGES=$(poetry run list)
+          for image in $IMAGES; do
+            trivy image --skip-update --severity HIGH,CRITICAL --exit-code 1 "$image"
+          done
+
       - name: Upload images
         if: success()
         run: |

--- a/.src/docker_build/main.py
+++ b/.src/docker_build/main.py
@@ -1,5 +1,11 @@
 import typer
-from docker_build.images import find_images, build_image, upload_tags
+from docker_build.images import (
+    find_images,
+    build_image,
+    upload_tags,
+    docker_image,
+    docker_tag,
+)
 from docker_build.validation import validate
 
 cli = typer.Typer()
@@ -21,3 +27,11 @@ def upload():
     for image, versions in images.items():
         for version in versions:
             upload_tags(image, version)
+
+
+@cli.command(help="List unique docker images managed by this tool")
+def list():
+    images = find_images()
+    for image, versions in images.items():
+        for version in versions:
+            print(docker_tag(image, version))

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Builds your Docker images automatically, like magic. Good for handling common base images for all your projects, apps,
 whatever.
 
+This repository builds images to [hub.docker.com/u/lietu](https://hub.docker.com/u/lietu)
+
 ## How do you use this then?
 
 Well, we got 3 things you need to worry about:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ loguru = "^0.5.3"
 [tool.poetry.scripts]
 build = "docker_build.main:build"
 upload = "docker_build.main:upload"
+list = "docker_build.main:list"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/python-base/ubuntu20.04-python3.9/Dockerfile
+++ b/python-base/ubuntu20.04-python3.9/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 
 ENV \
-    APT_PYTHON_VERSION="3.9" \
     DEBIAN_FRONTEND="noninteractive" \
     GID=1000 \
     GROUP="api" \
@@ -11,6 +10,7 @@ ENV \
     POETRY_HOME="/usr/local/poetry" \
     POETRY_VERSION="1.1.6" \
     PYTHONUNBUFFERED=1 \
+    PYTHON_VERSION="3.9" \
     TZ="UTC" \
     UID=1000 \
     USER="api" \

--- a/python-base/ubuntu20.04-python3.9/config.yaml
+++ b/python-base/ubuntu20.04-python3.9/config.yaml
@@ -4,9 +4,9 @@ tags:
   - ubuntu20.04-python
   - lts-python
   - ubuntu-python3.9
-  - poetry1.6.5
-  - lts-poetry1.6.5
-  - ubuntu-python-poetry1.6.5
-  - ubuntu-python3.9-poetry1.6.5
-  - ubuntu20.04-python-poetry1.6.5
-  - ubuntu20.04-python3.9-poetry1.6.5
+  - poetry1.1.6
+  - lts-poetry1.1.6
+  - ubuntu-python-poetry1.1.6
+  - ubuntu-python3.9-poetry1.1.6
+  - ubuntu20.04-python-poetry1.1.6
+  - ubuntu20.04-python3.9-poetry1.1.6

--- a/python-base/ubuntu20.04-python3.9/docker/base-prepare.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/base-prepare.sh
@@ -33,3 +33,5 @@ bash /src/docker/scripts/configure_poetry.sh
 # Cleanup
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+rm -rf /root/.cache
+rm -rf /usr/share/doc

--- a/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
@@ -16,7 +16,7 @@ bash /src/docker/scripts/configure_poetry.sh
 
 # Remove useless old vendor packages
 cd /usr/local/poetry/lib/poetry/_vendor/
-KEEP="py3.8 py3.9 py3.10"
+KEEP="py${PYTHON_VERSION}"
 for dir in py*; do
   if [[ ! $KEEP =~ (^|[[:space:]])$dir($|[[:space:]]) ]]; then
     rm -rf "${dir}"

--- a/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
@@ -13,3 +13,13 @@ su "${USER}" -c "python /tmp/get-poetry.py --version ${POETRY_VERSION}"
 
 chmod +x "${POETRY_HOME}"/bin/*
 bash /src/docker/scripts/configure_poetry.sh
+
+# Remove useless old vendor packages
+cd /usr/local/poetry/lib/poetry/_vendor/
+KEEP="py3.8 py3.9 py3.10"
+for dir in py*; do
+  if [[ ! $KEEP =~ (^|[[:space:]])$dir($|[[:space:]]) ]]; then
+    rm -rf "${dir}"
+  fi
+done
+cd -

--- a/python-base/ubuntu20.04-python3.9/docker/scripts/install_python.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/scripts/install_python.sh
@@ -5,14 +5,12 @@ set -exuo pipefail
 
 # Install python
 apt-get install -y --no-install-recommends \
-  "python${APT_PYTHON_VERSION}" \
+  "python${PYTHON_VERSION}" \
   python3-distutils
 
 # Set python active
-update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10
-update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 10
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+update-alternatives --install /usr/bin/python python "/usr/bin/python${PYTHON_VERSION}" 10
+update-alternatives --install /usr/bin/python3 python3 "/usr/bin/python${PYTHON_VERSION}" 10
 
 # Install Pip
 curl https://bootstrap.pypa.io/get-pip.py | python

--- a/python-base/ubuntu20.04-python3.9/docker/scripts/install_python.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/scripts/install_python.sh
@@ -10,6 +10,9 @@ apt-get install -y --no-install-recommends \
 
 # Set python active
 update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10
+update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 10
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
 # Install Pip
 curl https://bootstrap.pypa.io/get-pip.py | python

--- a/python-base/ubuntu20.04-python3.9/docker/scripts/install_python.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/scripts/install_python.sh
@@ -14,3 +14,7 @@ update-alternatives --install /usr/bin/python3 python3 "/usr/bin/python${PYTHON_
 
 # Install Pip
 curl https://bootstrap.pypa.io/get-pip.py | python
+
+# Clean up
+rm -rf /usr/lib/python3.8
+rm -rf /usr/bin/python3.8


### PR DESCRIPTION
 - Trivy security scanning
 - `poetry1.6.5` -> `poetry1.1.6`
 - Cleaning up Poetry install to not support 2.7, 3.5, 3.6, 3.7, 3.8, etc.
 - Fully activating Python 3.9 by also replacing `python3`