### PR TITLE
extend pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,6 @@ repos:
 
       # Prevent giant files from being committed
       - id: check-added-large-files
-        args: ["--maxkb=600"]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,19 @@ repos:
         args: ["--fix=crlf"]
         files: \.bat$
 
+      # Check for files that contain merge conflict strings
+      - id: check-merge-conflict
+
+      # Check for debugger imports and py37+ `breakpoint()` calls in python source
+      - id: debug-statements
+
+      # Check yaml files for parseable syntax
+      - id: check-yaml
+
+      # Prevent giant files from being committed
+      - id: check-added-large-files
+        args: ["--maxkb=600"]
+
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.0
     hooks:


### PR DESCRIPTION
Add check-merge-conflicts, debug-statements, check-yaml, check-added-large-files hooks to pre-commit hooks 