### PR TITLE
Restore Docker hub username

### DIFF
--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -32,8 +32,8 @@ jobs:
       - name: Upload images
         if: success()
         run: |
-          USERNAME=$(poetry run docker_username)
           echo "$PASSWORD" | docker login --username "$USERNAME" --password-stdin
           poetry run upload
         env:
           PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          USERNAME: lietu


### PR DESCRIPTION
Organizations like `digitallivinginternational` cannot have access tokens, so it's impossible to log in as the username from `settings.py` which is needed for other things.